### PR TITLE
Fix status bar / app bar colors

### DIFF
--- a/app/src/main/java/org/bottiger/podcast/DrawerActivity.java
+++ b/app/src/main/java/org/bottiger/podcast/DrawerActivity.java
@@ -103,7 +103,7 @@ public abstract class DrawerActivity extends MediaRouterPlaybackActivity impleme
     }
 
     public void exitFullScreen(@NonNull View argFullScreenView) {
-        UIUtils.resetStatusBar(this, null);
+        UIUtils.resetStatusBar(this);
     }
 
     public int getFragmentTop() {

--- a/app/src/main/java/org/bottiger/podcast/FragmentContainerActivity.java
+++ b/app/src/main/java/org/bottiger/podcast/FragmentContainerActivity.java
@@ -200,7 +200,7 @@ public class FragmentContainerActivity extends DrawerActivity {
                 }
 
                 if (!HasTinted) {
-                    UIUtils.resetStatusBar(activity, null);
+                    UIUtils.resetStatusBar(activity);
                 }
             }
             super.setPrimaryItem(container, position, object);

--- a/app/src/main/java/org/bottiger/podcast/utils/UIUtils.java
+++ b/app/src/main/java/org/bottiger/podcast/utils/UIUtils.java
@@ -36,6 +36,7 @@ import android.preference.PreferenceManager;
 import android.support.annotation.ColorRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.v4.content.ContextCompat;
 import android.text.Html;
 import android.text.Spannable;
 import android.text.SpannableStringBuilder;
@@ -368,21 +369,9 @@ public class UIUtils {
 
     @TargetApi(21)
     public static void resetStatusBar(@NonNull Activity argActivity, @Nullable Resources.Theme argTheme) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP){
-            Window window = argActivity.getWindow();
-            window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
-            int color;
-            @ColorRes int colorRes = R.color.colorPrimary;
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                color = argActivity.getResources().getColor(colorRes, argTheme);
-            } else {
-                color = argActivity.getResources().getColor(colorRes);
-            }
-            int r = Color.red(color);
-            int g = Color.green(color);
-            int b = Color.blue(color);
-            int opaqueColor = Color.argb(255, r, g ,b);
-            window.setStatusBarColor(opaqueColor);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            int color = ContextCompat.getColor(argActivity, R.color.colorPrimaryDark);
+            tintStatusBar(color, argActivity);
         }
     }
 

--- a/app/src/main/java/org/bottiger/podcast/utils/UIUtils.java
+++ b/app/src/main/java/org/bottiger/podcast/utils/UIUtils.java
@@ -367,12 +367,9 @@ public class UIUtils {
         }
     }
 
-    @TargetApi(21)
-    public static void resetStatusBar(@NonNull Activity argActivity, @Nullable Resources.Theme argTheme) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            int color = ContextCompat.getColor(argActivity, R.color.colorPrimaryDark);
-            tintStatusBar(color, argActivity);
-        }
+    public static void resetStatusBar(@NonNull Activity argActivity) {
+        int color = ContextCompat.getColor(argActivity, R.color.colorPrimaryDark);
+        tintStatusBar(color, argActivity);
     }
 
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="colorPrimary">#660000</color>
-    <color name="colorSecondary">#cc0000</color>
-    <color name="colorPrimaryDark">#DD330000</color>
+    <color name="colorPrimary">#f44336</color>
+    <color name="colorSecondary">#ef5350</color>
+    <color name="colorPrimaryDark">#d32f2f</color>
     <color name="colorAccent">#ff3d00</color>
 
     <color name="colorBgPrimary">#adadad</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -71,7 +71,7 @@
         <item name="android:windowTranslucentStatus" tools:targetApi="19">true</item> <!- top statusbar ->
         -->
 
-        <item name="android:statusBarColor" tools:targetApi="21">@color/colorPrimary</item>
+        <item name="android:statusBarColor" tools:targetApi="21">@color/colorPrimaryDark</item>
 
         <item name="android:windowNoTitle">true</item>
         <item name="windowActionBar">false</item>
@@ -253,7 +253,7 @@
     <style name="TransparentActionBar" parent="ActionBar">
         <!--<item name="android:background">@null</item>-->
         <item name="android:height">@dimen/action_bar_height</item>
-        <item name="android:background">@color/colorPrimaryDark</item> <!-- same as statusbar -->
+        <item name="android:background">@color/colorPrimary</item> <!-- same as statusbar -->
     </style>
 
     <style name="TranslucentActionBar" parent="ActionBar">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -58,8 +58,8 @@
         <!--<item name="android:colorBackground">@color/white_opaque</item>-->
 
         <item name="colorPrimary">@color/colorPrimary</item>
-        <item name="colorPrimaryDark">@color/colorSecondary</item>
-        <item name="colorAccent">@color/colorSecondary</item>
+        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+        <item name="colorAccent">@color/colorPrimary</item>
 
         <!--
         They are here because 4.1.2 will crash otherwise


### PR DESCRIPTION
- Use different colors for the app bar and status bar - [toolbar should be 500 tint, status bar should be 700 tint](https://www.google.com/design/spec/style/color.html#color-ui-color-application)
- UIUtils.resetStatusBar():
  - Replace ContextThemeWrapper.getColor(int) (deprecated in Marshmallow) with ContextCompat.getColor
  - Use logic in UIUtils.tintStatusBar() instead of duplicating it
  - Remove TargetApi annotation (ContextCompat is available down to API level 1)
  - Remove unused Theme argument
  - Tint to colorPrimaryDark instead of colorPrimary
- Use [material design colors](https://www.google.com/design/spec/style/color.html#color-color-palette) for app bar / status bar
