### PR TITLE
Disable auto-download and downloading over mobile networks by default

### DIFF
--- a/app/src/main/res/values/preferences_defaults.xml
+++ b/app/src/main/res/values/preferences_defaults.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <bool name="pref_download_on_update_default">false</bool>
-    <bool name="pref_download_only_wifi_default">false</bool>
+    <bool name="pref_download_only_wifi_default">true</bool>
     <bool name="pref_open_video_externally_default">false</bool>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -152,7 +152,7 @@
             android:key="pref_network_category_network">
 
         <CheckBoxPreference
-            android:defaultValue="true"
+            android:defaultValue="@bool/pref_download_on_update_default"
             android:key="@string/pref_download_on_update_key"
             android:summary="@string/pref_download_on_update_description"
             android:title="@string/pref_download_on_update_title" />


### PR DESCRIPTION
Having auto-download over mobile networks on by default is liable to use up a lot of cellular data/storage space. If the user doesn't go through the settings to discover this option, it could cost them a lot of money.