### PR TITLE
Fix timezone parsing

### DIFF
--- a/app/src/main/java/org/bottiger/podcast/utils/DateUtils.java
+++ b/app/src/main/java/org/bottiger/podcast/utils/DateUtils.java
@@ -108,10 +108,27 @@ public class DateUtils {
      */
     public static synchronized Date parse(@NonNull String dateString, @NonNull String dateFormat) throws ParseException {
 
+        Locale[] locales = {
+                Locale.getDefault(),
+                Locale.US, // Fallback locale for English day/month names (EEE/MMM)
+        };
         dateString = fixUnsupportedTimeZones(dateString);
 
-        SimpleDateFormat simpleDateFormat = getSimpleDateFormat(dateFormat, Locale.getDefault());
-        return simpleDateFormat.parse(dateString);
+        for (int i = 0; i < locales.length; i++) {
+            Locale locale = locales[i];
+            boolean last = i == locales.length - 1;
+            try {
+                SimpleDateFormat simpleDateFormat = getSimpleDateFormat(dateFormat, locale);
+                return simpleDateFormat.parse(dateString);
+            } catch (ParseException e) {
+                if (last) {
+                    throw e;
+                }
+            }
+        }
+
+        // Will never be executed, only to satisfy code analysis
+        return null;
     }
 
     private static String fixUnsupportedTimeZones(@NonNull String dateString) {

--- a/app/src/main/java/org/bottiger/podcast/utils/DateUtils.java
+++ b/app/src/main/java/org/bottiger/podcast/utils/DateUtils.java
@@ -59,11 +59,13 @@ public class DateUtils {
     }};
 
     private static final Map<String, String> UNSUPPORTED_TIME_ZONE = new HashMap<String, String>() {{
-        put("BST", "GMT+0100");
-        put("PST", "GMT-0800");
-        put("PDT", "GMT-0700");
-        put("EST", "GMT-0500");
-        put("EDT", "GMT-0400");
+        // There MUST be a colon between hours and minutes,
+        // see http://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html for details.
+        put("BST", "GMT+01:00");
+        put("PST", "GMT-08:00");
+        put("PDT", "GMT-07:00");
+        put("EST", "GMT-05:00");
+        put("EDT", "GMT-04:00");
     }};
 
     private static final Map<String, SimpleDateFormat> SIMPLE_DATE_FORMATS_LUT = new HashMap<>(DATE_FORMAT_REGEXPS.size());

--- a/app/src/main/java/org/bottiger/podcast/utils/DateUtils.java
+++ b/app/src/main/java/org/bottiger/podcast/utils/DateUtils.java
@@ -111,20 +111,26 @@ public class DateUtils {
 
         SimpleDateFormat simpleDateFormat = sSimpleDateFormatCache;
 
-        try {
-            // This is a hack to deal with time zones not known to Java
-            Iterator it = UNSUPPORTED_TIME_ZONE.entrySet().iterator();
-            while (it.hasNext()) {
-                Map.Entry pair = (Map.Entry) it.next();
-                dateString = dateString.replace(pair.getKey().toString(), pair.getValue().toString());
-            }
+        dateString = fixUnsupportedTimeZones(dateString);
 
+        try {
             simpleDateFormat = getSimpleDateFormat(dateFormat, Locale.getDefault());
             return simpleDateFormat.parse(dateString);
         } catch (ParseException pe) {
             ParseException pe2 = pe;
             return simpleDateFormat.parse(dateString);
         }
+    }
+
+    private static String fixUnsupportedTimeZones(@NonNull String dateString) {
+        String result = dateString;
+        // This is a hack to deal with time zones not known to Java
+        Iterator it = UNSUPPORTED_TIME_ZONE.entrySet().iterator();
+        while (it.hasNext()) {
+            Map.Entry pair = (Map.Entry) it.next();
+            result = result.replace(pair.getKey().toString(), pair.getValue().toString());
+        }
+        return result;
     }
 
     // Validators ---------------------------------------------------------------------------------

--- a/app/src/main/java/org/bottiger/podcast/utils/DateUtils.java
+++ b/app/src/main/java/org/bottiger/podcast/utils/DateUtils.java
@@ -119,7 +119,7 @@ public class DateUtils {
                 dateString = dateString.replace(pair.getKey().toString(), pair.getValue().toString());
             }
 
-            simpleDateFormat = getSimpleDateFormat(dateFormat);
+            simpleDateFormat = getSimpleDateFormat(dateFormat, Locale.getDefault());
             return simpleDateFormat.parse(dateString);
         } catch (ParseException pe) {
             ParseException pe2 = pe;
@@ -230,15 +230,16 @@ public class DateUtils {
         return sDateFormatKeys;
     }
 
-    private static SimpleDateFormat getSimpleDateFormat(@NonNull String argDateFormat) {
-        SimpleDateFormat simpleDateFormat = SIMPLE_DATE_FORMATS_LUT.get(argDateFormat);
+    private static SimpleDateFormat getSimpleDateFormat(@NonNull String argDateFormat, Locale locale) {
+        String lutKey = argDateFormat + locale.toString();
+        SimpleDateFormat simpleDateFormat = SIMPLE_DATE_FORMATS_LUT.get(lutKey);
 
         if (simpleDateFormat == null) {
             synchronized (SIMPLE_DATE_FORMATS_LUT) {
-                simpleDateFormat = new SimpleDateFormat(argDateFormat, Locale.getDefault());
+                simpleDateFormat = new SimpleDateFormat(argDateFormat, locale);
                 simpleDateFormat.setLenient(false); // Don't automatically convert invalid date.
 
-                SIMPLE_DATE_FORMATS_LUT.put(argDateFormat, simpleDateFormat);
+                SIMPLE_DATE_FORMATS_LUT.put(lutKey, simpleDateFormat);
             }
         }
 

--- a/app/src/main/java/org/bottiger/podcast/utils/DateUtils.java
+++ b/app/src/main/java/org/bottiger/podcast/utils/DateUtils.java
@@ -110,13 +110,8 @@ public class DateUtils {
 
         dateString = fixUnsupportedTimeZones(dateString);
 
-        try {
-            SimpleDateFormat simpleDateFormat = getSimpleDateFormat(dateFormat, Locale.getDefault());
-            return simpleDateFormat.parse(dateString);
-        } catch (ParseException pe) {
-            ParseException pe2 = pe;
-            return simpleDateFormat.parse(dateString);
-        }
+        SimpleDateFormat simpleDateFormat = getSimpleDateFormat(dateFormat, Locale.getDefault());
+        return simpleDateFormat.parse(dateString);
     }
 
     private static String fixUnsupportedTimeZones(@NonNull String dateString) {

--- a/app/src/main/java/org/bottiger/podcast/utils/DateUtils.java
+++ b/app/src/main/java/org/bottiger/podcast/utils/DateUtils.java
@@ -68,7 +68,6 @@ public class DateUtils {
 
     private static final Map<String, SimpleDateFormat> SIMPLE_DATE_FORMATS_LUT = new HashMap<>(DATE_FORMAT_REGEXPS.size());
     private static Pattern[] sDateFormatKeys = null;
-    private static SimpleDateFormat sSimpleDateFormatCache = null;
 
     public interface Hint {
         Pattern get();
@@ -109,12 +108,10 @@ public class DateUtils {
      */
     public static synchronized Date parse(@NonNull String dateString, @NonNull String dateFormat) throws ParseException {
 
-        SimpleDateFormat simpleDateFormat = sSimpleDateFormatCache;
-
         dateString = fixUnsupportedTimeZones(dateString);
 
         try {
-            simpleDateFormat = getSimpleDateFormat(dateFormat, Locale.getDefault());
+            SimpleDateFormat simpleDateFormat = getSimpleDateFormat(dateFormat, Locale.getDefault());
             return simpleDateFormat.parse(dateString);
         } catch (ParseException pe) {
             ParseException pe2 = pe;


### PR DESCRIPTION
These commits will fix date parsing problems for English dates (e.g. "Tue, 27 Jun 2017 18:14:21 GMT-0700") when the default locale is not English by falling back to trying with with English if the default locale fails.

Also fixing the unsupported time zone mapping constants to contain the required colon separators. Even though "GMT-0700" is accepted when testing on Android, this is outside of specification and this fails when compiling with javac on a desktop PC.

This error have made episodes for the Security Now! podcast never have correct date (all episodes get date from the last sync) which is really annoying.