### PR TITLE
Fix footer crash

### DIFF
--- a/app/src/main/java/org/bottiger/podcast/activities/discovery/FeedViewDiscoveryAdapter.java
+++ b/app/src/main/java/org/bottiger/podcast/activities/discovery/FeedViewDiscoveryAdapter.java
@@ -9,6 +9,8 @@ import android.widget.RelativeLayout;
 import org.bottiger.podcast.TopActivity;
 import org.bottiger.podcast.activities.feedview.EpisodeViewHolder;
 import org.bottiger.podcast.activities.feedview.FeedViewAdapter;
+import org.bottiger.podcast.activities.feedview.FeedViewHolder;
+import org.bottiger.podcast.activities.feedview.FooterViewHolder;
 import org.bottiger.podcast.provider.IEpisode;
 import org.bottiger.podcast.provider.ISubscription;
 import org.bottiger.podcast.views.PlayPauseButton;
@@ -25,8 +27,8 @@ public class FeedViewDiscoveryAdapter extends FeedViewAdapter {
     }
 
     @Override
-    public EpisodeViewHolder onCreateViewHolder(ViewGroup viewGroup, int i) {
-        EpisodeViewHolder viewHolder = super.onCreateViewHolder(viewGroup, i);
+    public FeedViewHolder onCreateViewHolder(ViewGroup viewGroup, int i) {
+        FeedViewHolder viewHolder = super.onCreateViewHolder(viewGroup, i);
 
         //ViewGroup.LayoutParams params = viewHolder.mPlayPauseButton.getLayoutParams();
         //params.width = (int)mActivity.getResources().getDimension(R.dimen.playpause_button_size_small);
@@ -44,9 +46,7 @@ public class FeedViewDiscoveryAdapter extends FeedViewAdapter {
         return mSubscription.getEpisodes().get(argPosition);
     }
 
-    @Override
-    public void onBindViewHolder(EpisodeViewHolder episodeViewHolder, final int position) {
-        super.onBindViewHolder(episodeViewHolder, position);
+    public void onBindEpisodeViewHolder(EpisodeViewHolder episodeViewHolder, final int position) {
         int dataPosition = getDatasetPosition(position);
         final IEpisode argEpisode = getItemForPosition(dataPosition);
 
@@ -66,5 +66,25 @@ public class FeedViewDiscoveryAdapter extends FeedViewAdapter {
         episodeViewHolder.mPlayPauseButton.setStatus(STATE_IDLE);
 
         getPalette(episodeViewHolder);
+    }
+
+    public void onBindFooterViewHolder(FooterViewHolder footerViewHolder, final int position) {
+    }
+
+    @Override
+    public void onBindViewHolder(FeedViewHolder feedViewHolder, final int position) {
+        super.onBindViewHolder(feedViewHolder, position);
+
+        if (feedViewHolder instanceof FooterViewHolder) {
+            onBindFooterViewHolder((FooterViewHolder) feedViewHolder, position);
+            return;
+        }
+
+        if (feedViewHolder instanceof EpisodeViewHolder) {
+            onBindEpisodeViewHolder((EpisodeViewHolder) feedViewHolder, position);
+            return;
+        }
+
+        throw new RuntimeException("Missing feedViewHolder instanceof check");
     }
 }

--- a/app/src/main/java/org/bottiger/podcast/activities/feedview/EpisodeViewHolder.java
+++ b/app/src/main/java/org/bottiger/podcast/activities/feedview/EpisodeViewHolder.java
@@ -25,7 +25,7 @@ import java.lang.annotation.RetentionPolicy;
 /**
  * Created by aplb on 01-10-2015.
  */
-public class EpisodeViewHolder extends RecyclerView.ViewHolder {
+public class EpisodeViewHolder extends FeedViewHolder {
 
     private static final String TAG = EpisodeViewHolder.class.getSimpleName();
 

--- a/app/src/main/java/org/bottiger/podcast/activities/feedview/FeedViewAdapter.java
+++ b/app/src/main/java/org/bottiger/podcast/activities/feedview/FeedViewAdapter.java
@@ -235,11 +235,30 @@ public class FeedViewAdapter extends RecyclerView.Adapter<EpisodeViewHolder> {
         throw new RuntimeException("Missing viewHolder instanceof check");
     }
 
+    private void onEpisodeViewRecycled(EpisodeViewHolder episodeViewHolder) {
+        episodeViewHolder.mDownloadButton.unsetEpisodeId();
+        episodeViewHolder.mPlayPauseButton.unsetEpisodeId();
+        episodeViewHolder.mQueueButton.unsetEpisodeId();
+    }
+
+    private void onFooterViewRecycled(FooterViewHolder footerViewHolder) {
+    }
+
     @Override
     public void onViewRecycled(EpisodeViewHolder viewHolder) {
-        viewHolder.mDownloadButton.unsetEpisodeId();
-        viewHolder.mPlayPauseButton.unsetEpisodeId();
-        viewHolder.mQueueButton.unsetEpisodeId();
+
+        // Since FooterViewHolder is a subclass of EpisodeViewHolder this test must be first.
+        if (viewHolder instanceof FooterViewHolder) {
+            onFooterViewRecycled((FooterViewHolder) viewHolder);
+            return;
+        }
+
+        if (viewHolder instanceof EpisodeViewHolder) {
+            onEpisodeViewRecycled(viewHolder);
+            return;
+        }
+
+        throw new RuntimeException("Missing viewHolder instanceof check");
     }
 
     public void setExpanded(boolean expanded) {

--- a/app/src/main/java/org/bottiger/podcast/activities/feedview/FeedViewAdapter.java
+++ b/app/src/main/java/org/bottiger/podcast/activities/feedview/FeedViewAdapter.java
@@ -122,14 +122,8 @@ public class FeedViewAdapter extends RecyclerView.Adapter<EpisodeViewHolder> {
         throw new RuntimeException("there is no type that matches the type " + viewType + " + make sure your using types correctly");
     }
 
-    @Override
-    public void onBindViewHolder(EpisodeViewHolder viewHolder, int position) {
-
-        if (viewHolder instanceof FooterViewHolder) {
-            return;
-        }
-
-        final int dataPosition = viewHolder.getAdapterPosition();
+    private void onBindEpisodeViewHolder(EpisodeViewHolder episodeViewHolder, int position) {
+        final int dataPosition = episodeViewHolder.getAdapterPosition();
         final IEpisode item = getItemForPosition(dataPosition);
 
         if (item == null) {
@@ -137,9 +131,8 @@ public class FeedViewAdapter extends RecyclerView.Adapter<EpisodeViewHolder> {
             return;
         }
 
-        SharedAdapterUtils.AddPaddingToLastElement((viewHolder).mContainer, 0, dataPosition == getItemCount()-1);
+        SharedAdapterUtils.AddPaddingToLastElement(episodeViewHolder.mContainer, 0, dataPosition == getItemCount()-1);
 
-        final EpisodeViewHolder episodeViewHolder = viewHolder;
         final boolean canDownload = item.canDownload();
         @SoundWavesPlayerBase.PlayerState int playerStatus = STATE_IDLE;
 
@@ -170,10 +163,11 @@ public class FeedViewAdapter extends RecyclerView.Adapter<EpisodeViewHolder> {
 
         episodeViewHolder.setState(state, canDownload);
 
+        final EpisodeViewHolder finalEpisodeViewHolder = episodeViewHolder;
         episodeViewHolder.itemView.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                FeedViewAdapter.this.onClick(episodeViewHolder, dataPosition, canDownload);
+                FeedViewAdapter.this.onClick(finalEpisodeViewHolder, dataPosition, canDownload);
             }
         });
 
@@ -188,10 +182,29 @@ public class FeedViewAdapter extends RecyclerView.Adapter<EpisodeViewHolder> {
         SoundWaves.getAppContext(mActivity).getPlayer().addListener(episodeViewHolder.mPlayPauseButton);
         episodeViewHolder.mDownloadButton.enabledProgressListener(true);
 
-        getPalette(viewHolder);
+        getPalette(episodeViewHolder);
 
         episodeViewHolder.mPlayPauseButton.setStatus(playerStatus);
+    }
 
+    private void onBindFooterViewHolder(FooterViewHolder footerViewHolder, int position) {
+    }
+
+    @Override
+    public void onBindViewHolder(EpisodeViewHolder viewHolder, int position) {
+
+        // Since FooterViewHolder is a subclass of EpisodeViewHolder this test must be first.
+        if (viewHolder instanceof FooterViewHolder) {
+            onBindFooterViewHolder((FooterViewHolder) viewHolder, position);
+            return;
+        }
+
+        if (viewHolder instanceof EpisodeViewHolder) {
+            onBindEpisodeViewHolder(viewHolder, position);
+            return;
+        }
+
+        throw new RuntimeException("Missing viewHolder instanceof check");
     }
 
     public void onClick(EpisodeViewHolder episodeViewHolder, int dataPosition, boolean argCanDownload) {

--- a/app/src/main/java/org/bottiger/podcast/activities/feedview/FeedViewAdapter.java
+++ b/app/src/main/java/org/bottiger/podcast/activities/feedview/FeedViewAdapter.java
@@ -40,7 +40,7 @@ import static org.bottiger.podcast.player.SoundWavesPlayerBase.STATE_READY;
 /**
  * Created by apl on 02-09-2014.
  */
-public class FeedViewAdapter extends RecyclerView.Adapter<FeedViewHolder> {
+public class FeedViewAdapter extends FeedViewAdapterBase {
 
     @Retention(RetentionPolicy.SOURCE)
     @IntDef({RECENT_FIRST, OLDEST_FIRST})
@@ -122,7 +122,8 @@ public class FeedViewAdapter extends RecyclerView.Adapter<FeedViewHolder> {
         throw new RuntimeException("there is no type that matches the type " + viewType + " + make sure your using types correctly");
     }
 
-    private void onBindEpisodeViewHolder(EpisodeViewHolder episodeViewHolder, int position) {
+    @Override
+    protected void onBindViewHolderEpisode(EpisodeViewHolder episodeViewHolder, int position) {
         final int dataPosition = episodeViewHolder.getAdapterPosition();
         final IEpisode item = getItemForPosition(dataPosition);
 
@@ -187,26 +188,8 @@ public class FeedViewAdapter extends RecyclerView.Adapter<FeedViewHolder> {
         episodeViewHolder.mPlayPauseButton.setStatus(playerStatus);
     }
 
-    private void onBindFooterViewHolder(FooterViewHolder footerViewHolder, int position) {
-    }
-
     @Override
-    public void onBindViewHolder(FeedViewHolder feedViewHolder, int position) {
-
-        if (feedViewHolder instanceof FooterViewHolder) {
-            onBindFooterViewHolder((FooterViewHolder) feedViewHolder, position);
-            return;
-        }
-
-        if (feedViewHolder instanceof EpisodeViewHolder) {
-            onBindEpisodeViewHolder((EpisodeViewHolder) feedViewHolder, position);
-            return;
-        }
-
-        throw new RuntimeException("Missing feedViewHolder instanceof check");
-    }
-
-    private void onClickEpisode(EpisodeViewHolder episodeViewHolder, int dataPosition, boolean argCanDownload) {
+    protected void onClickEpisode(EpisodeViewHolder episodeViewHolder, int dataPosition, boolean argCanDownload) {
         @EpisodeViewHolder.DisplayState int newState = episodeViewHolder.toggleState(argCanDownload);
         if (newState == EpisodeViewHolder.EXPANDED) {
             mExpanededItems.add(dataPosition);
@@ -215,78 +198,22 @@ public class FeedViewAdapter extends RecyclerView.Adapter<FeedViewHolder> {
         }
     }
 
-    private void onClickFooter(FooterViewHolder footerViewHolder, int dataPosition, boolean argCanDownload) {
-    }
 
-    public void onClick(FeedViewHolder feedViewHolder, int dataPosition, boolean argCanDownload) {
-
-        if (feedViewHolder instanceof FooterViewHolder) {
-            onClickFooter((FooterViewHolder) feedViewHolder, dataPosition, argCanDownload);
-            return;
-        }
-
-        if (feedViewHolder instanceof EpisodeViewHolder) {
-            onClickEpisode((EpisodeViewHolder) feedViewHolder, dataPosition, argCanDownload);
-            return;
-        }
-
-        throw new RuntimeException("Missing feedViewHolder instanceof check");
+    @Override
+    protected void onViewAttachedToWindowEpisode(EpisodeViewHolder episodeViewHolder) {
     }
 
     @Override
-    public void onViewAttachedToWindow (FeedViewHolder holder) {
-        super.onViewAttachedToWindow(holder);
-    }
-
-    private void onEpisodeViewDetachedFromWindow(EpisodeViewHolder episodeViewHolder) {
+    protected void onViewDetachedFromWindowEpisode(EpisodeViewHolder episodeViewHolder) {
         SoundWaves.getAppContext(mActivity).getPlayer().removeListener(episodeViewHolder.mPlayPauseButton);
         episodeViewHolder.mDownloadButton.enabledProgressListener(false);
     }
 
-    private void onFooterViewDetachedFromWindow(FooterViewHolder footerViewHolder) {
-    }
-
     @Override
-    public void onViewDetachedFromWindow(FeedViewHolder feedViewHolder) {
-
-        if (feedViewHolder instanceof FooterViewHolder) {
-            onFooterViewDetachedFromWindow((FooterViewHolder) feedViewHolder);
-            super.onViewDetachedFromWindow(feedViewHolder);
-            return;
-        }
-
-        if (feedViewHolder instanceof EpisodeViewHolder) {
-            onEpisodeViewDetachedFromWindow((EpisodeViewHolder) feedViewHolder);
-            super.onViewDetachedFromWindow(feedViewHolder);
-            return;
-        }
-
-        throw new RuntimeException("Missing feedViewHolder instanceof check");
-    }
-
-    private void onEpisodeViewRecycled(EpisodeViewHolder episodeViewHolder) {
+    protected void onViewRecycledEpisode(EpisodeViewHolder episodeViewHolder) {
         episodeViewHolder.mDownloadButton.unsetEpisodeId();
         episodeViewHolder.mPlayPauseButton.unsetEpisodeId();
         episodeViewHolder.mQueueButton.unsetEpisodeId();
-    }
-
-    private void onFooterViewRecycled(FooterViewHolder footerViewHolder) {
-    }
-
-    @Override
-    public void onViewRecycled(FeedViewHolder feedViewHolder) {
-
-        if (feedViewHolder instanceof FooterViewHolder) {
-            onFooterViewRecycled((FooterViewHolder) feedViewHolder);
-            return;
-        }
-
-        if (feedViewHolder instanceof EpisodeViewHolder) {
-            onEpisodeViewRecycled((EpisodeViewHolder) feedViewHolder);
-            return;
-        }
-
-        throw new RuntimeException("Missing feedViewHolder instanceof check");
     }
 
     public void setExpanded(boolean expanded) {
@@ -357,7 +284,8 @@ public class FeedViewAdapter extends RecyclerView.Adapter<FeedViewHolder> {
         return mStringBuilder.toString();
     }
 
-    private void getPaletteEpisode(@NonNull final EpisodeViewHolder episodeViewHolder) {
+    @Override
+    protected void getPaletteEpisode(@NonNull final EpisodeViewHolder episodeViewHolder) {
         mSubscription.getColors(mActivity)
                 .subscribeOn(io.reactivex.schedulers.Schedulers.io())
                 .observeOn(io.reactivex.android.schedulers.AndroidSchedulers.mainThread())
@@ -370,24 +298,6 @@ public class FeedViewAdapter extends RecyclerView.Adapter<FeedViewHolder> {
                         episodeViewHolder.mDownloadButton.onPaletteFound(value);
                     }
                 });
-    }
-
-    private void getPaletteFooter(@NonNull final FooterViewHolder footerViewHolder) {
-    }
-
-    protected void getPalette(@NonNull final FeedViewHolder feedViewHolder) {
-
-        if (feedViewHolder instanceof FooterViewHolder) {
-            getPaletteFooter((FooterViewHolder) feedViewHolder);
-            return;
-        }
-
-        if (feedViewHolder instanceof EpisodeViewHolder) {
-            getPaletteEpisode((EpisodeViewHolder) feedViewHolder);
-            return;
-        }
-
-        throw new RuntimeException("Missing feedViewHolder instanceof check");
     }
 
     public @Order int calcOrder() {

--- a/app/src/main/java/org/bottiger/podcast/activities/feedview/FeedViewAdapter.java
+++ b/app/src/main/java/org/bottiger/podcast/activities/feedview/FeedViewAdapter.java
@@ -40,7 +40,7 @@ import static org.bottiger.podcast.player.SoundWavesPlayerBase.STATE_READY;
 /**
  * Created by apl on 02-09-2014.
  */
-public class FeedViewAdapter extends RecyclerView.Adapter<EpisodeViewHolder> {
+public class FeedViewAdapter extends RecyclerView.Adapter<FeedViewHolder> {
 
     @Retention(RetentionPolicy.SOURCE)
     @IntDef({RECENT_FIRST, OLDEST_FIRST})
@@ -109,7 +109,7 @@ public class FeedViewAdapter extends RecyclerView.Adapter<EpisodeViewHolder> {
     }
 
     @Override
-    public EpisodeViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+    public FeedViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
 
         View view;
         if (viewType == EPISODE_TYPE) {
@@ -191,20 +191,19 @@ public class FeedViewAdapter extends RecyclerView.Adapter<EpisodeViewHolder> {
     }
 
     @Override
-    public void onBindViewHolder(EpisodeViewHolder viewHolder, int position) {
+    public void onBindViewHolder(FeedViewHolder feedViewHolder, int position) {
 
-        // Since FooterViewHolder is a subclass of EpisodeViewHolder this test must be first.
-        if (viewHolder instanceof FooterViewHolder) {
-            onBindFooterViewHolder((FooterViewHolder) viewHolder, position);
+        if (feedViewHolder instanceof FooterViewHolder) {
+            onBindFooterViewHolder((FooterViewHolder) feedViewHolder, position);
             return;
         }
 
-        if (viewHolder instanceof EpisodeViewHolder) {
-            onBindEpisodeViewHolder(viewHolder, position);
+        if (feedViewHolder instanceof EpisodeViewHolder) {
+            onBindEpisodeViewHolder((EpisodeViewHolder) feedViewHolder, position);
             return;
         }
 
-        throw new RuntimeException("Missing viewHolder instanceof check");
+        throw new RuntimeException("Missing feedViewHolder instanceof check");
     }
 
     private void onClickEpisode(EpisodeViewHolder episodeViewHolder, int dataPosition, boolean argCanDownload) {
@@ -219,24 +218,23 @@ public class FeedViewAdapter extends RecyclerView.Adapter<EpisodeViewHolder> {
     private void onClickFooter(FooterViewHolder footerViewHolder, int dataPosition, boolean argCanDownload) {
     }
 
-    public void onClick(EpisodeViewHolder viewHolder, int dataPosition, boolean argCanDownload) {
+    public void onClick(FeedViewHolder feedViewHolder, int dataPosition, boolean argCanDownload) {
 
-        // Since FooterViewHolder is a subclass of EpisodeViewHolder this test must be first.
-        if (viewHolder instanceof FooterViewHolder) {
-            onClickFooter((FooterViewHolder) viewHolder, dataPosition, argCanDownload);
+        if (feedViewHolder instanceof FooterViewHolder) {
+            onClickFooter((FooterViewHolder) feedViewHolder, dataPosition, argCanDownload);
             return;
         }
 
-        if (viewHolder instanceof EpisodeViewHolder) {
-            onClickEpisode(viewHolder, dataPosition, argCanDownload);
+        if (feedViewHolder instanceof EpisodeViewHolder) {
+            onClickEpisode((EpisodeViewHolder) feedViewHolder, dataPosition, argCanDownload);
             return;
         }
 
-        throw new RuntimeException("Missing viewHolder instanceof check");
+        throw new RuntimeException("Missing feedViewHolder instanceof check");
     }
 
     @Override
-    public void onViewAttachedToWindow (EpisodeViewHolder holder) {
+    public void onViewAttachedToWindow (FeedViewHolder holder) {
         super.onViewAttachedToWindow(holder);
     }
 
@@ -249,22 +247,21 @@ public class FeedViewAdapter extends RecyclerView.Adapter<EpisodeViewHolder> {
     }
 
     @Override
-    public void onViewDetachedFromWindow(EpisodeViewHolder viewHolder) {
+    public void onViewDetachedFromWindow(FeedViewHolder feedViewHolder) {
 
-        // Since FooterViewHolder is a subclass of EpisodeViewHolder this test must be first.
-        if (viewHolder instanceof FooterViewHolder) {
-            onFooterViewDetachedFromWindow((FooterViewHolder) viewHolder);
-            super.onViewDetachedFromWindow(viewHolder);
+        if (feedViewHolder instanceof FooterViewHolder) {
+            onFooterViewDetachedFromWindow((FooterViewHolder) feedViewHolder);
+            super.onViewDetachedFromWindow(feedViewHolder);
             return;
         }
 
-        if (viewHolder instanceof EpisodeViewHolder) {
-            onEpisodeViewDetachedFromWindow(viewHolder);
-            super.onViewDetachedFromWindow(viewHolder);
+        if (feedViewHolder instanceof EpisodeViewHolder) {
+            onEpisodeViewDetachedFromWindow((EpisodeViewHolder) feedViewHolder);
+            super.onViewDetachedFromWindow(feedViewHolder);
             return;
         }
 
-        throw new RuntimeException("Missing viewHolder instanceof check");
+        throw new RuntimeException("Missing feedViewHolder instanceof check");
     }
 
     private void onEpisodeViewRecycled(EpisodeViewHolder episodeViewHolder) {
@@ -277,20 +274,19 @@ public class FeedViewAdapter extends RecyclerView.Adapter<EpisodeViewHolder> {
     }
 
     @Override
-    public void onViewRecycled(EpisodeViewHolder viewHolder) {
+    public void onViewRecycled(FeedViewHolder feedViewHolder) {
 
-        // Since FooterViewHolder is a subclass of EpisodeViewHolder this test must be first.
-        if (viewHolder instanceof FooterViewHolder) {
-            onFooterViewRecycled((FooterViewHolder) viewHolder);
+        if (feedViewHolder instanceof FooterViewHolder) {
+            onFooterViewRecycled((FooterViewHolder) feedViewHolder);
             return;
         }
 
-        if (viewHolder instanceof EpisodeViewHolder) {
-            onEpisodeViewRecycled(viewHolder);
+        if (feedViewHolder instanceof EpisodeViewHolder) {
+            onEpisodeViewRecycled((EpisodeViewHolder) feedViewHolder);
             return;
         }
 
-        throw new RuntimeException("Missing viewHolder instanceof check");
+        throw new RuntimeException("Missing feedViewHolder instanceof check");
     }
 
     public void setExpanded(boolean expanded) {
@@ -379,20 +375,19 @@ public class FeedViewAdapter extends RecyclerView.Adapter<EpisodeViewHolder> {
     private void getPaletteFooter(@NonNull final FooterViewHolder footerViewHolder) {
     }
 
-    protected void getPalette(@NonNull final EpisodeViewHolder viewHolder) {
+    protected void getPalette(@NonNull final FeedViewHolder feedViewHolder) {
 
-        // Since FooterViewHolder is a subclass of EpisodeViewHolder this test must be first.
-        if (viewHolder instanceof FooterViewHolder) {
-            getPaletteFooter((FooterViewHolder) viewHolder);
+        if (feedViewHolder instanceof FooterViewHolder) {
+            getPaletteFooter((FooterViewHolder) feedViewHolder);
             return;
         }
 
-        if (viewHolder instanceof EpisodeViewHolder) {
-            getPaletteEpisode(viewHolder);
+        if (feedViewHolder instanceof EpisodeViewHolder) {
+            getPaletteEpisode((EpisodeViewHolder) feedViewHolder);
             return;
         }
 
-        throw new RuntimeException("Missing viewHolder instanceof check");
+        throw new RuntimeException("Missing feedViewHolder instanceof check");
     }
 
     public @Order int calcOrder() {

--- a/app/src/main/java/org/bottiger/podcast/activities/feedview/FeedViewAdapter.java
+++ b/app/src/main/java/org/bottiger/podcast/activities/feedview/FeedViewAdapter.java
@@ -208,11 +208,31 @@ public class FeedViewAdapter extends RecyclerView.Adapter<EpisodeViewHolder> {
         super.onViewAttachedToWindow(holder);
     }
 
+    private void onEpisodeViewDetachedFromWindow(EpisodeViewHolder episodeViewHolder) {
+        SoundWaves.getAppContext(mActivity).getPlayer().removeListener(episodeViewHolder.mPlayPauseButton);
+        episodeViewHolder.mDownloadButton.enabledProgressListener(false);
+    }
+
+    private void onFooterViewDetachedFromWindow(FooterViewHolder footerViewHolder) {
+    }
+
     @Override
-    public void onViewDetachedFromWindow(EpisodeViewHolder holder) {
-        SoundWaves.getAppContext(mActivity).getPlayer().removeListener(holder.mPlayPauseButton);
-        holder.mDownloadButton.enabledProgressListener(false);
-        super.onViewDetachedFromWindow(holder);
+    public void onViewDetachedFromWindow(EpisodeViewHolder viewHolder) {
+
+        // Since FooterViewHolder is a subclass of EpisodeViewHolder this test must be first.
+        if (viewHolder instanceof FooterViewHolder) {
+            onFooterViewDetachedFromWindow((FooterViewHolder) viewHolder);
+            super.onViewDetachedFromWindow(viewHolder);
+            return;
+        }
+
+        if (viewHolder instanceof EpisodeViewHolder) {
+            onEpisodeViewDetachedFromWindow(viewHolder);
+            super.onViewDetachedFromWindow(viewHolder);
+            return;
+        }
+
+        throw new RuntimeException("Missing viewHolder instanceof check");
     }
 
     @Override

--- a/app/src/main/java/org/bottiger/podcast/activities/feedview/FeedViewAdapter.java
+++ b/app/src/main/java/org/bottiger/podcast/activities/feedview/FeedViewAdapter.java
@@ -329,7 +329,7 @@ public class FeedViewAdapter extends RecyclerView.Adapter<EpisodeViewHolder> {
         return mStringBuilder.toString();
     }
 
-    protected void getPalette(@NonNull final EpisodeViewHolder episodeViewHolder) {
+    private void getPaletteEpisode(@NonNull final EpisodeViewHolder episodeViewHolder) {
         mSubscription.getColors(mActivity)
                 .subscribeOn(io.reactivex.schedulers.Schedulers.io())
                 .observeOn(io.reactivex.android.schedulers.AndroidSchedulers.mainThread())
@@ -342,6 +342,25 @@ public class FeedViewAdapter extends RecyclerView.Adapter<EpisodeViewHolder> {
                         episodeViewHolder.mDownloadButton.onPaletteFound(value);
                     }
                 });
+    }
+
+    private void getPaletteFooter(@NonNull final FooterViewHolder footerViewHolder) {
+    }
+
+    protected void getPalette(@NonNull final EpisodeViewHolder viewHolder) {
+
+        // Since FooterViewHolder is a subclass of EpisodeViewHolder this test must be first.
+        if (viewHolder instanceof FooterViewHolder) {
+            getPaletteFooter((FooterViewHolder) viewHolder);
+            return;
+        }
+
+        if (viewHolder instanceof EpisodeViewHolder) {
+            getPaletteEpisode(viewHolder);
+            return;
+        }
+
+        throw new RuntimeException("Missing viewHolder instanceof check");
     }
 
     public @Order int calcOrder() {

--- a/app/src/main/java/org/bottiger/podcast/activities/feedview/FeedViewAdapter.java
+++ b/app/src/main/java/org/bottiger/podcast/activities/feedview/FeedViewAdapter.java
@@ -207,13 +207,32 @@ public class FeedViewAdapter extends RecyclerView.Adapter<EpisodeViewHolder> {
         throw new RuntimeException("Missing viewHolder instanceof check");
     }
 
-    public void onClick(EpisodeViewHolder episodeViewHolder, int dataPosition, boolean argCanDownload) {
+    private void onClickEpisode(EpisodeViewHolder episodeViewHolder, int dataPosition, boolean argCanDownload) {
         @EpisodeViewHolder.DisplayState int newState = episodeViewHolder.toggleState(argCanDownload);
         if (newState == EpisodeViewHolder.EXPANDED) {
             mExpanededItems.add(dataPosition);
         } else {
             mExpanededItems.remove(Integer.valueOf(dataPosition));
         }
+    }
+
+    private void onClickFooter(FooterViewHolder footerViewHolder, int dataPosition, boolean argCanDownload) {
+    }
+
+    public void onClick(EpisodeViewHolder viewHolder, int dataPosition, boolean argCanDownload) {
+
+        // Since FooterViewHolder is a subclass of EpisodeViewHolder this test must be first.
+        if (viewHolder instanceof FooterViewHolder) {
+            onClickFooter((FooterViewHolder) viewHolder, dataPosition, argCanDownload);
+            return;
+        }
+
+        if (viewHolder instanceof EpisodeViewHolder) {
+            onClickEpisode(viewHolder, dataPosition, argCanDownload);
+            return;
+        }
+
+        throw new RuntimeException("Missing viewHolder instanceof check");
     }
 
     @Override

--- a/app/src/main/java/org/bottiger/podcast/activities/feedview/FeedViewAdapterBase.java
+++ b/app/src/main/java/org/bottiger/podcast/activities/feedview/FeedViewAdapterBase.java
@@ -1,0 +1,150 @@
+package org.bottiger.podcast.activities.feedview;
+
+import android.support.annotation.NonNull;
+import android.support.v7.widget.RecyclerView;
+import android.view.ViewGroup;
+
+import org.bottiger.podcast.TopActivity;
+import org.bottiger.podcast.provider.ISubscription;
+
+/**
+ * Base class for FeedViewAdapter, consolidating all type checking and differencing in one place.
+ */
+public abstract class FeedViewAdapterBase extends RecyclerView.Adapter<FeedViewHolder> {
+
+    @Override
+    public abstract FeedViewHolder onCreateViewHolder(ViewGroup parent, int viewType);
+
+    protected void onBindViewHolderEpisode(EpisodeViewHolder episodeViewHolder, int position) {
+    }
+
+    protected void onBindViewHolderFooter(FooterViewHolder footerViewHolder, int position) {
+    }
+
+    @Override
+    public void onBindViewHolder(FeedViewHolder feedViewHolder, int position) {
+
+        if (feedViewHolder instanceof FooterViewHolder) {
+            onBindViewHolderFooter((FooterViewHolder) feedViewHolder, position);
+            return;
+        }
+
+        if (feedViewHolder instanceof EpisodeViewHolder) {
+            onBindViewHolderEpisode((EpisodeViewHolder) feedViewHolder, position);
+            return;
+        }
+
+        throw new RuntimeException("Missing feedViewHolder instanceof check");
+    }
+
+    protected void onClickEpisode(EpisodeViewHolder episodeViewHolder, int dataPosition, boolean argCanDownload) {
+    }
+
+    protected void onClickFooter(FooterViewHolder footerViewHolder, int dataPosition, boolean argCanDownload) {
+    }
+
+    public void onClick(FeedViewHolder feedViewHolder, int dataPosition, boolean argCanDownload) {
+
+        if (feedViewHolder instanceof FooterViewHolder) {
+            onClickFooter((FooterViewHolder) feedViewHolder, dataPosition, argCanDownload);
+            return;
+        }
+
+        if (feedViewHolder instanceof EpisodeViewHolder) {
+            onClickEpisode((EpisodeViewHolder) feedViewHolder, dataPosition, argCanDownload);
+            return;
+        }
+
+        throw new RuntimeException("Missing feedViewHolder instanceof check");
+    }
+
+    protected void onViewAttachedToWindowEpisode(EpisodeViewHolder episodeViewHolder) {
+    }
+
+    protected void onViewAttachedToWindowFooter(FooterViewHolder footerViewHolder) {
+    }
+
+    @Override
+    public void onViewAttachedToWindow(FeedViewHolder feedViewHolder) {
+        super.onViewAttachedToWindow(feedViewHolder);
+
+        if (feedViewHolder instanceof FooterViewHolder) {
+            onViewAttachedToWindowFooter((FooterViewHolder) feedViewHolder);
+            return;
+        }
+
+        if (feedViewHolder instanceof EpisodeViewHolder) {
+            onViewAttachedToWindowEpisode((EpisodeViewHolder) feedViewHolder);
+            return;
+        }
+
+        throw new RuntimeException("Missing feedViewHolder instanceof check");
+    }
+
+    protected void onViewDetachedFromWindowEpisode(EpisodeViewHolder episodeViewHolder) {
+    }
+
+    protected void onViewDetachedFromWindowFooter(FooterViewHolder footerViewHolder) {
+    }
+
+    @Override
+    public void onViewDetachedFromWindow(FeedViewHolder feedViewHolder) {
+
+        if (feedViewHolder instanceof FooterViewHolder) {
+            onViewDetachedFromWindowFooter((FooterViewHolder) feedViewHolder);
+            super.onViewDetachedFromWindow(feedViewHolder);
+            return;
+        }
+
+        if (feedViewHolder instanceof EpisodeViewHolder) {
+            onViewDetachedFromWindowEpisode((EpisodeViewHolder) feedViewHolder);
+            super.onViewDetachedFromWindow(feedViewHolder);
+            return;
+        }
+
+        throw new RuntimeException("Missing feedViewHolder instanceof check");
+    }
+
+    protected void onViewRecycledEpisode(EpisodeViewHolder episodeViewHolder) {
+    }
+
+    protected void onViewRecycledFooter(FooterViewHolder footerViewHolder) {
+    }
+
+    @Override
+    public void onViewRecycled(FeedViewHolder feedViewHolder) {
+
+        if (feedViewHolder instanceof FooterViewHolder) {
+            onViewRecycledFooter((FooterViewHolder) feedViewHolder);
+            return;
+        }
+
+        if (feedViewHolder instanceof EpisodeViewHolder) {
+            onViewRecycledEpisode((EpisodeViewHolder) feedViewHolder);
+            return;
+        }
+
+        throw new RuntimeException("Missing feedViewHolder instanceof check");
+    }
+
+    protected void getPaletteEpisode(@NonNull final EpisodeViewHolder episodeViewHolder) {
+    }
+
+    protected void getPaletteFooter(@NonNull final FooterViewHolder footerViewHolder) {
+    }
+
+    protected void getPalette(@NonNull final FeedViewHolder feedViewHolder) {
+
+        if (feedViewHolder instanceof FooterViewHolder) {
+            getPaletteFooter((FooterViewHolder) feedViewHolder);
+            return;
+        }
+
+        if (feedViewHolder instanceof EpisodeViewHolder) {
+            getPaletteEpisode((EpisodeViewHolder) feedViewHolder);
+            return;
+        }
+
+        throw new RuntimeException("Missing feedViewHolder instanceof check");
+    }
+}

--- a/app/src/main/java/org/bottiger/podcast/activities/feedview/FeedViewHolder.java
+++ b/app/src/main/java/org/bottiger/podcast/activities/feedview/FeedViewHolder.java
@@ -1,0 +1,13 @@
+package org.bottiger.podcast.activities.feedview;
+
+import android.support.v7.widget.RecyclerView;
+import android.view.View;
+
+/**
+ * Common base class for the feed view holders.
+ */
+public class FeedViewHolder extends RecyclerView.ViewHolder {
+    public FeedViewHolder(View view) {
+        super(view);
+    }
+}

--- a/app/src/main/java/org/bottiger/podcast/activities/feedview/FooterViewHolder.java
+++ b/app/src/main/java/org/bottiger/podcast/activities/feedview/FooterViewHolder.java
@@ -1,13 +1,12 @@
 package org.bottiger.podcast.activities.feedview;
 
-import android.support.v7.widget.RecyclerView;
 import android.view.View;
 
 /**
  * Created by aplb on 20-06-2017.
  */
 
-public class FooterViewHolder extends EpisodeViewHolder {
+public class FooterViewHolder extends FeedViewHolder {
 
     public FooterViewHolder(View itemView) {
         super(itemView);


### PR DESCRIPTION
Whenever I went to the end of the list of podcast episodes and scrolled back, the application crashed. This was due to FooterViewHolder not instancing some member that EpisodeViewHolder do, and the adapter not differentiating between the two types of view holders.

I have fixed this by making the adapter handle the types separately (type checking offloaded to a separate FeedViewAdapterBase class), and create a FeedViewHolder base class for FooterViewHolder 
and EpisodeViewHolder.

FeedViewDiscoveryAdapter could have been given a similar base class, but since only one function was affected I opted not to, but if wanted I could change this as well.
